### PR TITLE
Add half-hour tracking support

### DIFF
--- a/info.py
+++ b/info.py
@@ -22,7 +22,7 @@ def read_completed_tasks_from_csv():
             date,  projectname, project_id, task_name, work_hours = row
             if project_id not in completed_tasks:
                 completed_tasks[project_id] = []
-            completed_tasks[project_id].append({'task': task_name, 'hours': int(work_hours)})
+            completed_tasks[project_id].append({'task': task_name, 'hours': float(work_hours)})
 
 
 # Read completed tasks from the uploaded CSV file
@@ -47,7 +47,7 @@ def print_remaining_hours():
 
 
 def total_remaining_hours():
-    total_hours = 0
+    total_hours = 0.0
     for project_details in projects:
         project_id = project_details['id']
         remaining_hours = project_details['total_hours']
@@ -57,7 +57,7 @@ def total_remaining_hours():
     return total_hours
 
 def total_projects_hours():
-    total_hours = 0
+    total_hours = 0.0
     for project_details in projects:
         project_id = project_details['id']
         project_hours = project_details['total_hours']

--- a/migrate.py
+++ b/migrate.py
@@ -115,10 +115,10 @@ def generate_priority_work_schedule_with_total_hours_alternating(date, pm, task_
 
                 # Check if the task fits into the remaining work hours
                 if remaining_work_hours - task_hours >= 0:
-                    writer.writerow([date, project['name'], project_id, task['task'], task_hours])
+                    writer.writerow([date, project['name'], project_id, task['task'], f"{task_hours:.1f}"])
                     remaining_work_hours -= task_hours
                     if project_id not in pm.completed_tasks:
-                        pm.completed_tasks[project_id] = {'tasks': [], 'total_hours': 0}
+                        pm.completed_tasks[project_id] = {'tasks': [], 'total_hours': 0.0}
                     pm.completed_tasks[project_id]['tasks'].append(task['task'])
                     pm.completed_tasks[project_id]['total_hours'] += task_hours
     
@@ -180,8 +180,8 @@ def generate_priority_work_schedule_with_total_hours(date, pm, task_categories, 
                 # Skip tasks that exceed the project's total work hours
                 if existing_total_hours + task_hours > project_details['total_hours']:
                     continue
-                # write to works to output_csv_path    
-                writer.writerow([date, project_details['name'], project_id, task['task'], task_hours])
+                # write to works to output_csv_path
+                writer.writerow([date, project_details['name'], project_id, task['task'], f"{task_hours:.1f}"])
                 # print(f"{project_details['name']}, {project_id}, {task['task']}, {task_hours}")
                 # Update remaining work hours for the day
                 remaining_work_hours -= task_hours
@@ -190,7 +190,7 @@ def generate_priority_work_schedule_with_total_hours(date, pm, task_categories, 
                 # print(f"remaining_work_hours: {remaining_work_hours}, existing_total_hours: {existing_total_hours} ")
                 
                 if project_id not in pm.completed_tasks:
-                    pm.completed_tasks[project_id] = {'tasks': [], 'total_hours': 0}
+                    pm.completed_tasks[project_id] = {'tasks': [], 'total_hours': 0.0}
                 pm.completed_tasks[project_id]['tasks'].append(task['task'])
                 pm.completed_tasks[project_id]['total_hours'] += task_hours
     if(remaining_work_hours > 0 and max_work_hours > remaining_work_hours):

--- a/project_module/ProjectManager.py
+++ b/project_module/ProjectManager.py
@@ -25,9 +25,9 @@ class ProjectManager:
                     continue
                 date, project_name, project_id, task_name, work_hours = row
                 if project_id not in self.completed_tasks:
-                    self.completed_tasks[project_id] = {'tasks': [], 'total_hours': 0}
+                    self.completed_tasks[project_id] = {'tasks': [], 'total_hours': 0.0}
                 self.completed_tasks[project_id]['tasks'].append(task_name)
-                self.completed_tasks[project_id]['total_hours'] += int(work_hours)
+                self.completed_tasks[project_id]['total_hours'] += float(work_hours)
     
     # 這是演算法處理期間可運用的method     
     def update_priority_based_on_remaining_hours(self):
@@ -35,7 +35,7 @@ class ProjectManager:
             project_id = project_details['id']
             remaining_hours = project_details['total_hours']
             # 检索项目的已完成任务和总工时
-            project_tasks = self.completed_tasks.get(project_id, {'tasks': [], 'total_hours': 0})
+            project_tasks = self.completed_tasks.get(project_id, {'tasks': [], 'total_hours': 0.0})
             task_hours = project_tasks['total_hours']
             remaining_hours -= task_hours
             project_details['remaining_hours'] = remaining_hours

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ In conf/config.json:
 
 - priority_method: Provides two priority algorithms. The first is the LongestJobFirst algorithm, where projects with longer work hours have higher priority. The second is the AlternatingApproach algorithm, which alternates between sets of projects with longer and shorter work hours to generate daily tasks. This ensures that shorter tasks are not delayed for too long, making it suitable for months with unforeseen leave or absences. The default setting is AlternatingApproach.
 
-- maxhours: The number of work hours in a day, expressed as a positive integer.
+- maxhours: The number of work hours in a day, expressed as a positive number (half-hour increments like `3.5` are supported).
 
 - alternating_flag: True or False, used for recording purposes.
 

--- a/readme.zh.md
+++ b/readme.zh.md
@@ -62,7 +62,7 @@ python setup.py install
 
 - priority_method: 提供两种优先级算法。第一种是 LongestJobFirst，工时较长的项目具有更高的优先级。第二种是 AlternatingApproach，交替处理工时长短不一的项目集，以生成每日任务。这确保短期任务不会被过度延迟，适用于有突发休假或缺席的月份。默认设置为 AlternatingApproach。
 
-- maxhours: 一天中的工作时数，以正整数表示。
+- maxhours: 一天中的工作时数，以正数表示，可支援半小时（例如 `3.5`）。
 
 - alternating_flag: 为 True 或 False，用于记录目的。
 

--- a/repair.py
+++ b/repair.py
@@ -22,7 +22,7 @@ def read_completed_tasks_from_csv():
             date,  projectname, project_id, task_name, work_hours = row
             if project_id not in completed_tasks:
                 completed_tasks[project_id] = []
-            completed_tasks[project_id].append({'task': task_name, 'hours': int(work_hours)})
+            completed_tasks[project_id].append({'task': task_name, 'hours': float(work_hours)})
 
 
 # Read completed tasks from the uploaded CSV file


### PR DESCRIPTION
## Summary
- parse completed task hours as `float` instead of `int`
- handle float totals in `ProjectManager`, `info`, and `repair`
- write hours to CSV with one decimal place
- document half-hour configuration in readmes

## Testing
- `python -m py_compile project_module/ProjectManager.py info.py repair.py migrate.py`
- `python test.py`

resolves #2 

------
https://chatgpt.com/codex/tasks/task_e_68527ef10680832c99c95a0261d68f2d